### PR TITLE
Firefox Extension Support

### DIFF
--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -40,6 +40,10 @@ enum RuntimeContext {
 }
 
 const ENDPOINT_RE = /^((?:background$)|devtools|content-script|window)(?:@(\d+))?$/;
+
+// Return true if the `chrome` object has a particular property
+const hasChrome = (prop: string): boolean => (typeof chrome !== 'undefined' && chrome[prop]);
+
 /**
  * Bridge
  * @external
@@ -48,9 +52,9 @@ class Bridge {
     private static ctxname: string = null;
     private static id: string = null;
     private static context: RuntimeContext =
-        (chrome.devtools) ? RuntimeContext.Devtools
-            : (chrome.tabs) ? RuntimeContext.Background
-                : (chrome.extension) ? RuntimeContext.ContentScript
+        hasChrome('devtools') ? RuntimeContext.Devtools
+            : hasChrome('tabs') ? RuntimeContext.Background
+                : hasChrome('extension') ? RuntimeContext.ContentScript
                     : (typeof document === 'undefined' && typeof importScripts === 'function') ? RuntimeContext.Worker
                         : (typeof document !== 'undefined' && window.top !== window) ? RuntimeContext.Frame
                             : (typeof document !== 'undefined') ? RuntimeContext.Window : null;


### PR DESCRIPTION
Firefox supports much of the `chrome.*` extension API in order to make it easy to port chrome extensions to Firefox (and it's also related to the standard WebExtensions standard). The only difference, in this case, is that in some contexts (content script, window), the `chrome` value doesn't exist and the browser will throw an exception if you try to access it directly.

The change to make this portable to Firefox was quite trivial: we just need to verify `chrome` is defined before we check the property on it.

I have verified this with the [LocalForageExplorer](https://github.com/jgillick/LocalForageExplorer) plugin, which I'm porting to Firefox.