### PR TITLE
Lower target version to prevent optional chaining operator being in dist

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "esnext",
+        "target": "es2018",
         "outDir": "./dist",
         "jsx": "react",
         "sourceMap": true,


### PR DESCRIPTION
Optional chaining operator (`?.`) is not supported by older versions of webpack and might cause compilation issues.

This PR lower the target version to `es2018` to transpile it to older syntax.  