### PR TITLE
refactor: ships esm instead of cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.1",
   "description": "Messaging in Chrome extensions made easy. Out of the box.",
   "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "target": "es2018",
+        "module": "esnext",
+        "target": "esnext",
         "outDir": "./dist",
         "jsx": "react",
         "sourceMap": true,
         "declaration": true,
         "esModuleInterop": true,
+        "moduleResolution": "node",
         "declarationDir": "./dist"
     },
     "exclude": [


### PR DESCRIPTION
As this package is supported to work with bundlers (if I understand correctly), shipping es moudle instead of cjs would have better static-analyze support for bundlers (tree-shaking and better module detection, etc.)