### PR TITLE
refactor: ships esm instead of cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "crx-bridge",
   "version": "3.0.1",
   "description": "Messaging in Chrome extensions made easy. Out of the box.",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/index.mjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "watch": "tsc -w"
+    "build": "tsup src/index.ts --format esm,cjs --no-splitting --dts",
+    "watch": "npm run build -- --watch"
   },
   "repository": {
     "type": "git",
@@ -34,18 +34,18 @@
   "homepage": "https://github.com/NeekSandhu/crx-bridge#readme",
   "devDependencies": {
     "@types/node": "^8.0.46",
-    "@types/serialize-error": "^4.0.1",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.1",
     "eslint": "^7.11.0",
     "eslint-import-resolver-typescript": "^2.3.0",
     "eslint-plugin-import": "^2.22.1",
+    "tsup": "^4.12.5",
     "type-fest": "^0.18.0",
     "typescript": "^4.0.3"
   },
   "dependencies": {
     "oneline": "^1.0.3",
-    "serialize-error": "^2.1.0",
+    "serialize-error": "^8.1.0",
     "tiny-uid": "^1.1.1",
     "webextension-polyfill-ts": "^0.20.0"
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.1",
   "description": "Messaging in Chrome extensions made easy. Out of the box.",
   "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w"

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1,6 +1,6 @@
 import { JsonValue } from 'type-fest';
 import { browser, Runtime } from 'webextension-polyfill-ts';
-import * as serializeError from 'serialize-error';
+import { serializeError } from 'serialize-error';
 import oneline from 'oneline';
 import uuid from 'tiny-uid';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "target": "es2018",
+        "module": "esnext",
+        "target": "esnext",
         "outDir": "./dist",
         "jsx": "react",
         "sourceMap": true,
         "declaration": true,
         "esModuleInterop": true,
+        "moduleResolution": "node",
         "declarationDir": "./dist"
     },
     "exclude": [


### PR DESCRIPTION
This PR continues #8, as this might be an opinion choice, just raising this as an option. If you like it, you might take this and close #8.

[tsup](https://github.com/egoist/tsup) allows to bundle the package and generate dts within single file. You can find more on it's doc.